### PR TITLE
Fix access to special_tokens function since it was changed

### DIFF
--- a/dataloader.py
+++ b/dataloader.py
@@ -54,8 +54,8 @@ class AudioDataset(Dataset):
         else:
             special_tokens = [
                 self.tokenizer.sot,
-                self.tokenizer._get_single_token_id(f"<|{language}|>"),
-                self.tokenizer._get_single_token_id("<|transcribe|>"),
+                self.tokenizer.special_tokens.get(f"<|{language}|>"),
+                self.tokenizer.special_tokens.get("<|transcribe|>"),
             ]
             if no_timestamps:
                 special_tokens.append(self.tokenizer.no_timestamps)


### PR DESCRIPTION
Since commit https://github.com/openai/whisper/commit/839639a223b92ad61851baae9ad8a695ccb41ce5 the Whisper's Tokenizer changed the function used for getting the special tokens. This fixes how the special token is accessed from the dataloader.